### PR TITLE
fix regression introduced by new typing_extension version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.11
+
+- Fix regression introduced by `typing_extensions` version 4.6.0+.
+
 ## 0.2.10
 
 - Support for `formatter_class` in `Parser`.

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,6 +19,9 @@ warn_unused_ignores = False
 [mypy-typed_argparse.parser]
 warn_unused_ignores = False
 
+[mypy-typed_argparse.type_utils]
+warn_unused_ignores = False
+
 [mypy-examples.example_sub_commands]
 warn_unused_ignores = False
 
@@ -26,4 +29,7 @@ warn_unused_ignores = False
 warn_unused_ignores = False
 
 [mypy-tests.test_type_utils]
+warn_unused_ignores = False
+
+[mypy-tests.test_typed_args]
 warn_unused_ignores = False

--- a/tests/test_type_utils.py
+++ b/tests/test_type_utils.py
@@ -95,7 +95,7 @@ def test_type_annotation__literals__from_typing_extensions() -> None:
 )
 def test_type_annotation__literals__from_typing() -> None:
     # Literal can behave differently whether it comes from typing or typing_extensions
-    from typing import Literal
+    from typing import Literal  # type: ignore
 
     t = TypeAnnotation(Literal[1, 2, 3])
 

--- a/tests/test_type_utils.py
+++ b/tests/test_type_utils.py
@@ -1,6 +1,7 @@
+import sys
 from typing import List, Optional
 
-from typing_extensions import Literal
+import pytest
 
 from typed_argparse.type_utils import TypeAnnotation, collect_type_annotations
 
@@ -72,8 +73,35 @@ def test_type_annotation__mixed_list_optional() -> None:
     assert t.raw_type is str
 
 
-def test_type_annotation__literals() -> None:
+def test_type_annotation__literals__from_typing_extensions() -> None:
+    # Literal can behave differently whether it comes from typing or typing_extensions
+    from typing_extensions import Literal
+
     t = TypeAnnotation(Literal[1, 2, 3])
+
+    allowed_values = t.get_allowed_values_if_literal()
+    assert allowed_values == (1, 2, 3)
+
+    assert t.validate(1) == (1, None)
+    assert t.validate(2) == (2, None)
+    assert t.validate(3) == (3, None)
+    assert t.validate(4) == (4, "value 4 does not match any allowed literal value in (1, 2, 3)")
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 8),
+    reason="Literal only available in Python 3.8+",
+    # https://docs.python.org/3/library/typing.html#typing.Literal
+)
+def test_type_annotation__literals__from_typing() -> None:
+    # Literal can behave differently whether it comes from typing or typing_extensions
+    from typing import Literal
+
+    t = TypeAnnotation(Literal[1, 2, 3])
+
+    allowed_values = t.get_allowed_values_if_literal()
+    assert allowed_values == (1, 2, 3)
+
     assert t.validate(1) == (1, None)
     assert t.validate(2) == (2, None)
     assert t.validate(3) == (3, None)

--- a/tests/test_typed_args.py
+++ b/tests/test_typed_args.py
@@ -1,11 +1,18 @@
 import argparse
 import enum
-from typing import List, NewType, Optional, Union
+import sys
 
 import pytest
-from typing_extensions import Literal
 
 from typed_argparse import TypedArgs, WithUnionType
+
+if sys.version_info < (3, 8):
+    from typing import List, NewType, Optional, Union
+
+    from typing_extensions import Literal
+else:
+    from typing import List, Literal, NewType, Optional, Union
+
 
 # -----------------------------------------------------------------------------
 # Basics

--- a/typed_argparse/__init__.py
+++ b/typed_argparse/__init__.py
@@ -3,7 +3,7 @@ from .choices import Choices, get_choices_from, get_choices_from_class
 from .parser import Binding, Bindings, Parser, SubParser, SubParserGroup
 from .typed_args import TypedArgs, WithUnionType, validate_type_union
 
-VERSION = "0.2.10"
+VERSION = "0.2.11"
 
 __all__ = [
     "Choices",

--- a/typed_argparse/type_utils.py
+++ b/typed_argparse/type_utils.py
@@ -160,7 +160,9 @@ class TypeAnnotation:
             # it necessary to properly detect literal instance.
             # In Python 3.8+, Literal has been integrated into typing itself.
             # Using the import from typing_extensions should make it work in both cases.
-            if self.origin is LiteralFromTypingExtension or self.origin is LiteralFromTyping:
+            if self.origin is LiteralFromTypingExtension or (
+                LiteralFromTyping is not None and self.origin is LiteralFromTyping
+            ):
                 return self.args
             else:
                 return None

--- a/typed_argparse/type_utils.py
+++ b/typed_argparse/type_utils.py
@@ -13,7 +13,13 @@ from typing import (
     get_type_hints,
 )
 
-from typing_extensions import Literal
+from typing_extensions import Literal as LiteralFromTypingExtension
+
+if sys.version_info >= (3, 8):
+    from typing import Literal as LiteralFromTyping
+else:
+    LiteralFromTyping = None
+
 
 _NoneType = type(None)
 
@@ -154,7 +160,7 @@ class TypeAnnotation:
             # it necessary to properly detect literal instance.
             # In Python 3.8+, Literal has been integrated into typing itself.
             # Using the import from typing_extensions should make it work in both cases.
-            if self.origin is Literal:
+            if self.origin is LiteralFromTypingExtension or self.origin is LiteralFromTyping:
                 return self.args
             else:
                 return None

--- a/typed_argparse/type_utils.py
+++ b/typed_argparse/type_utils.py
@@ -16,7 +16,7 @@ from typing import (
 from typing_extensions import Literal as LiteralFromTypingExtension
 
 if sys.version_info >= (3, 8):
-    from typing import Literal as LiteralFromTyping
+    from typing import Literal as LiteralFromTyping  # type: ignore
 else:
     LiteralFromTyping = None
 


### PR DESCRIPTION
This PR fixes a regression introduced by `typing_extensions` version 4.6.0+. The cause of the issue is as follows:

In [version 4.6.0](https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-460-may-22-2023) typing_extension backports the `Literal` even to Python version 3.8. Previously in `typing_extensions` used more or less an alias of `typing.Literal` on Python 3.8, because it is available. In typed_argparse the code was only using `typing_extension.Literal` for backwards compatibility reason. The logic to detect the handling of literals was based on comparing the given type against `typing_extension.Literal`, and if the comparison was positive the literal handling worked. So far this logic worked even when users on Python 3.8 were using `typing.Literal` because it was an alias, and the comparison worked. With the new version of typing_extension there is a real difference between `typing.Literal` (on user side) and the `typing_extension.Literal` (on typed_argparse side). Therefore typed_argparse failed to detect these literals as such.

The PR fixes it by comparing it against both possible `Literal` types.