### PR TITLE
move formatting of defaults to FormatterClass

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -893,10 +893,14 @@ def test_formatter_class_support(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 @pre_python_10
-def test_supression_of_help_text(capsys: pytest.CaptureFixture[str]) -> None:
+@pytest.mark.parametrize("auto_default_help", (True, False))
+def test_supression_of_help_text(
+    capsys: pytest.CaptureFixture[str],
+    auto_default_help: bool,
+) -> None:
     class Args(TypedArgs):
         epsilon: float = arg(help="Some epsilon", default=0.1)
-        hidden: float = arg(help=SUPPRESS, default=0.2)
+        hidden: float = arg(help=SUPPRESS, default=0.2, auto_default_help=auto_default_help)
 
     parser = Parser(Args)
     with pytest.raises(SystemExit):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -823,6 +823,31 @@ def test_defaults_in_help_text__off_if_desired(capsys: pytest.CaptureFixture[str
     )
 
 
+@pre_python_10
+def test_defaults_in_help_text__off_for_booleans(capsys: pytest.CaptureFixture[str]) -> None:
+    class Args(TypedArgs):
+        implicit: bool = arg(help="Some implicit 'on' switch")
+        enable: bool = arg(help="Some 'on' switch", default=False)
+        disable: bool = arg(help="Some 'off' switch", default=True)
+
+    parser = Parser(Args)
+    with pytest.raises(SystemExit):
+        parser.parse_args(["-h"])
+
+    captured = capsys.readouterr()
+    assert captured.out == textwrap.dedent(
+        """\
+        usage: pytest [-h] [--implicit] [--enable] [--disable]
+
+        optional arguments:
+          -h, --help  show this help message and exit
+          --implicit  Some implicit 'on' switch
+          --enable    Some 'on' switch
+          --disable   Some 'off' switch
+        """
+    )
+
+
 # Support of formatter class in help texts
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Type, TypeVar
 import pytest
 from typing_extensions import Literal
 
-from typed_argparse import Parser, TypedArgs, arg, SUPPRESS
+from typed_argparse import SUPPRESS, Parser, TypedArgs, arg
 from typed_argparse.parser import Bindings
 
 from ._testing_utils import argparse_error, compare_verbose, pre_python_10
@@ -780,6 +780,7 @@ def test_defaults_in_help_text__on_by_default(capsys: pytest.CaptureFixture[str]
         """
     )
 
+
 @pre_python_10
 def test_defaults_in_help_text__requires_formatter(capsys: pytest.CaptureFixture[str]) -> None:
     class Args(TypedArgs):
@@ -864,6 +865,7 @@ def test_formatter_class_support(capsys: pytest.CaptureFixture[str]) -> None:
 
 
 # Supression of help text
+
 
 @pre_python_10
 def test_supression_of_help_text(capsys: pytest.CaptureFixture[str]) -> None:

--- a/typed_argparse/__init__.py
+++ b/typed_argparse/__init__.py
@@ -1,6 +1,9 @@
+from argparse import SUPPRESS
+
 from .arg import Arg, arg
 from .choices import Choices, get_choices_from, get_choices_from_class
 from .exceptions import SubParserConflict
+from .formatter import DefaultHelpFormatter
 from .parser import Binding, Bindings, Parser, SubParser, SubParserGroup
 from .typed_args import TypedArgs, WithUnionType, validate_type_union
 
@@ -12,12 +15,14 @@ __all__ = [
     "Binding",
     "Bindings",
     "Choices",
+    "DefaultHelpFormatter",
     "get_choices_from_class",
     "get_choices_from",
     "Parser",
     "SubParser",
     "SubParserConflict",
     "SubParserGroup",
+    "SUPPRESS",
     "TypedArgs",
     "validate_type_union",
     "WithUnionType",

--- a/typed_argparse/formatter.py
+++ b/typed_argparse/formatter.py
@@ -1,0 +1,23 @@
+import argparse
+from typing import Optional
+
+
+class DefaultHelpFormatter(argparse.HelpFormatter):
+    class Unformatted(str):
+        pass
+
+    def _get_help_string(self, action: argparse.Action) -> Optional[str]:
+        if (
+            not isinstance(action.help, DefaultHelpFormatter.Unformatted)
+            and action.help is not None
+            and action.default is not None
+            and action.default is not argparse.SUPPRESS
+        ):
+            try:
+                from yachalk import chalk  # pyright: ignore
+
+                return f"{action.help} {chalk.gray(f'[default: {action.default}]')}"
+            except ImportError:
+                return f"{action.help} [default: {action.default}]"
+        else:
+            return action.help

--- a/typed_argparse/formatter.py
+++ b/typed_argparse/formatter.py
@@ -11,6 +11,8 @@ class DefaultHelpFormatter(argparse.HelpFormatter):
             not isinstance(action.help, DefaultHelpFormatter.Unformatted)
             and action.help is not None
             and action.default is not None
+            and action.default is not True
+            and action.default is not False
             and action.default is not argparse.SUPPRESS
         ):
             try:

--- a/typed_argparse/formatter.py
+++ b/typed_argparse/formatter.py
@@ -13,6 +13,8 @@ class DefaultHelpFormatter(argparse.HelpFormatter):
             and action.default is not None
             and action.default is not True
             and action.default is not False
+            # Setting default=SUPPRESS is not supported by typed-argparse, but is used
+            # by argparse for the help (-h/--help) and version (-v/--version) actions.
             and action.default is not argparse.SUPPRESS
         ):
             try:

--- a/typed_argparse/parser.py
+++ b/typed_argparse/parser.py
@@ -598,6 +598,7 @@ def _build_add_argument_args(
 
     return name_or_flags, kwargs
 
+
 def _to_string(args_or_group: ArgsOrGroup) -> str:
     if isinstance(args_or_group, type):
         return args_or_group.__name__

--- a/typed_argparse/parser.py
+++ b/typed_argparse/parser.py
@@ -477,7 +477,7 @@ def _build_add_argument_args(
 ) -> Tuple[List[str], Dict[str, Any]]:
 
     help = arg.help
-    if help is not None and not arg.auto_default_help:
+    if help is not None and help is not argparse.SUPPRESS and not arg.auto_default_help:
         help = DefaultHelpFormatter.Unformatted(help)
 
     kwargs: Dict[str, Any] = {

--- a/typed_argparse/parser.py
+++ b/typed_argparse/parser.py
@@ -28,6 +28,7 @@ from .arg import Arg
 from .arg import arg as make_arg
 from .choices import Choices
 from .exceptions import SubParserConflict
+from .formatter import DefaultHelpFormatter
 from .type_utils import TypeAnnotation, collect_type_annotations
 from .typed_args import TypedArgs
 
@@ -132,7 +133,7 @@ class Parser:
         epilog: Optional[str] = None,
         add_help: bool = True,
         allow_abbrev: bool = True,
-        formatter_class: Optional[FormatterClass] = None,
+        formatter_class: Optional[FormatterClass] = DefaultHelpFormatter,
     ):
         """
         The parser constructor requires one positional argument, which is either
@@ -475,8 +476,12 @@ def _build_add_argument_args(
     arg: Arg,
 ) -> Tuple[List[str], Dict[str, Any]]:
 
+    help = arg.help
+    if help is not None and not arg.auto_default_help:
+        help = DefaultHelpFormatter.Unformatted(help)
+
     kwargs: Dict[str, Any] = {
-        "help": _generate_help_text(arg),
+        "help": help,
     }
 
     # Unwrap optionals
@@ -592,21 +597,6 @@ def _build_add_argument_args(
         kwargs["dest"] = python_arg_name
 
     return name_or_flags, kwargs
-
-
-def _generate_help_text(arg: Arg) -> Optional[str]:
-    if arg.help is not None and arg.default is not None and arg.auto_default_help:
-
-        try:
-            from yachalk import chalk  # pyright: ignore
-
-            return f"{arg.help} {chalk.gray(f'[default: {arg.default}]')}"
-
-        except ImportError:
-            return f"{arg.help} [default: {arg.default}]"
-    else:
-        return arg.help
-
 
 def _to_string(args_or_group: ArgsOrGroup) -> str:
     if isinstance(args_or_group, type):


### PR DESCRIPTION
This patch moves the formatting of default values into a new `FormatterClass` that is then set as the default for `Parser`.

This was originally motivated by the observation that `help=SUPPRESS` did not work to hide arguments from -h/--help output (due to being mangled by `_generate_help_text`), and the subsequent realization that you cannot easily override the formatting of default values. Currently you'd have to set `auto_default_help` for every argument in addition to supplying a `FormatterClass`.

I tried to keep the `auto_default_help` functionality intact, but I didn't see obvious way to generalize it. So it'll only affect the formatter class I implemented. I'm not really happy with that part, but personally I'd probably just remove `auto_default_help` entirely.