### PR TITLE
fix singular optional positional arguments

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -196,6 +196,25 @@ def test_positional__sandwiched() -> None:
     assert args.single_after == "baz"
 
 
+def test_positional__optional_type() -> None:
+    class Args(TypedArgs):
+        value: Optional[int] = arg(positional=True)
+
+    args = parse(Args, ["123"])
+    assert args.value == 123
+
+    args = parse(Args, [])
+    assert args.value is None
+
+
+def test_positional__optional_bool_not_allowed() -> None:
+    class Args(TypedArgs):
+        value: Optional[bool] = arg(positional=True)
+
+    with pytest.raises(RuntimeError, match="Positional bool argument not supported"):
+        parse(Args, [])
+
+
 # Flags
 
 

--- a/typed_argparse/parser.py
+++ b/typed_argparse/parser.py
@@ -528,6 +528,9 @@ def _build_add_argument_args(
         else:
             kwargs["action"] = "store_true"
 
+        if arg.positional:
+            raise RuntimeError("Positional bool argument not supported")
+
     else:
         # We must not declare 'type' for boolean switches, which have an action instead.
         if arg.type is not None:
@@ -541,11 +544,11 @@ def _build_add_argument_args(
             default_value = arg.resolve_default()
             kwargs["default"] = default_value
 
-            # Argparse requires positionals with defaults to have nargs="?"
-            # Note that for list-like (real nargs) arguments that happens to have a default
-            # (a list as well), the nargs value will be overwritten below.
-            if arg.positional:
-                kwargs["nargs"] = "?"
+        # Argparse requires positionals with defaults to have nargs="?"
+        # Note that for list-like (real nargs) arguments that happens to have a default
+        # (a list as well), the nargs value will be overwritten below.
+        if arg.positional and (arg.has_default() or is_optional):
+            kwargs["nargs"] = "?"
 
         allowed_values_if_literal = annotation.get_allowed_values_if_literal()
         if allowed_values_if_literal is not None:


### PR DESCRIPTION
This patch fixes optional values for singular positional arguments, for cases such as 

    infile: Path = tap.arg(positional=True)
    outfile: Optional[Path] = tap.arg(positional=True)

Previously `outfile` would not be flagged as optional. Typical use cases are specifying output files, a single additional input file of a different type (e.g. an index file), or a common paramenter (e.g. a key or coordinates to look up).


I also added a check for boolean positional arguments, since that was possible but resulted in arguments that could not be set by the user and that were listed inconsistently in the help text. This

    arg: Optional[bool] = tap.arg(help="some help", positional=True)

for example became

	usage: example.py [-h]

	positional arguments:
	  arg         some help

	options:
	  -h, --help  show this help message and exit

Note that `arg` is mising from `usage:`.
