### PR TITLE
Add support for NamedTuple

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ include_package_data = true
 install_requires =
     setuptools
     importlib_resources
-python_requires = >=3.8
+python_requires = >=3.9
 
 [tool:pytest]
 addopts = --cov=typed_argparse --cov-report term-missing --cov-report html:.cov_html --cov-report=xml

--- a/typed_argparse/actions.py
+++ b/typed_argparse/actions.py
@@ -1,0 +1,62 @@
+import argparse
+from gettext import gettext, ngettext
+from typing import Sequence, Type
+
+
+class NamedTupleAction(argparse.Action):
+    def __init__(
+        self, option_strings: list[str], dest: str, type: Type, nargs=None, metavar=None, **kwargs
+    ):
+        assert metavar is None, "metavar is not None"
+
+        is_list = nargs is not None
+        if not is_list:
+            nargs = 1
+
+        if isinstance(nargs, int):
+            metavar = tuple((field.upper() for _ in range(nargs) for field in type._fields))
+            nargs = len(metavar)
+        else:
+            metavar = " ".join((field.upper() for field in type._fields))
+
+        super().__init__(option_strings, dest, type=None, nargs=nargs, metavar=metavar, **kwargs)
+
+        self._type = type
+        self.is_list = is_list
+
+    def field_type_at_index(self, index: int):
+        field = self._type._fields[index]
+        return self._type.__annotations__[field]
+
+    def parse_value(self, index: int, value: str):
+        field_type = self.field_type_at_index(index)
+        try:
+            return field_type(value)
+        except (TypeError, ValueError):
+            name = getattr(field_type, "__name__", repr(field_type))
+            args = {"type": name, "value": value}
+            msg = gettext("invalid %(type)s value: %(value)r")
+            raise argparse.ArgumentError(self, msg % args)
+
+    def parse_values(self, values: Sequence[str]):
+        return self._type(*(self.parse_value(i, value) for i, value in enumerate(values)))
+
+    def parse(self, values: Sequence[str]):
+        if self.is_list:
+            n = len(self._type._fields)
+            values_len = len(values)
+            if values_len % n != 0:
+                msg = gettext("expected at least %s arguments") % (
+                    values_len + n - (values_len % n)
+                )
+                raise argparse.ArgumentError(self, msg)
+
+            return [self.parse_values(values[i : i + n]) for i in range(0, values_len, n)]
+        else:
+            return self.parse_values(values)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if not isinstance(values, list):
+            raise ValueError(values)
+
+        setattr(namespace, self.dest, self.parse(values))

--- a/typed_argparse/arg.py
+++ b/typed_argparse/arg.py
@@ -6,6 +6,7 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
+    Tuple,
     TypeVar,
     Union,
     overload,
@@ -25,7 +26,7 @@ class Arg(NamedTuple):
     type: Optional[Callable[[str], object]]
     nargs: Optional[NArgs]
     help: Optional[str]
-    metavar: Optional[str]
+    metavar: Optional[Union[str, Tuple[str, ...]]]
     auto_default_help: bool
 
     def has_default(self) -> bool:
@@ -65,8 +66,7 @@ def arg(
     metavar: Optional[str] = ...,
     auto_default_help: bool = ...,
     default: T,
-) -> T:
-    ...
+) -> T: ...
 
 
 @overload
@@ -77,8 +77,7 @@ def arg(
     metavar: Optional[str] = ...,
     auto_default_help: bool = ...,
     dynamic_default: Optional[Callable[[], T]],
-) -> T:
-    ...
+) -> T: ...
 
 
 @overload
@@ -89,8 +88,7 @@ def arg(
     metavar: Optional[str] = ...,
     auto_default_help: bool = ...,
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
-) -> T:
-    ...
+) -> T: ...
 
 
 @overload
@@ -101,8 +99,7 @@ def arg(
     metavar: Optional[str] = ...,
     auto_default_help: bool = ...,
     type: Callable[[str], T],
-) -> T:
-    ...
+) -> T: ...
 
 
 # Same for nargs
@@ -113,12 +110,11 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     default: Sequence[T],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 @overload
@@ -126,12 +122,11 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     dynamic_default: Optional[Callable[[], Sequence[T]]],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 @overload
@@ -139,12 +134,11 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 @overload
@@ -152,12 +146,11 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     type: Callable[[str], T],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 # Overloads for cases with two 'type revealing' field set
@@ -172,8 +165,7 @@ def arg(
     auto_default_help: bool = ...,
     default: T,
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
-) -> T:
-    ...
+) -> T: ...
 
 
 @overload
@@ -185,8 +177,7 @@ def arg(
     auto_default_help: bool = ...,
     dynamic_default: Optional[Callable[[], T]],
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
-) -> T:
-    ...
+) -> T: ...
 
 
 @overload
@@ -198,8 +189,7 @@ def arg(
     auto_default_help: bool = ...,
     default: T,
     type: Callable[[str], T],
-) -> T:
-    ...
+) -> T: ...
 
 
 @overload
@@ -211,8 +201,7 @@ def arg(
     auto_default_help: bool = ...,
     dynamic_default: Optional[Callable[[], T]],
     type: Callable[[str], T],
-) -> T:
-    ...
+) -> T: ...
 
 
 @overload
@@ -224,8 +213,7 @@ def arg(
     auto_default_help: bool = ...,
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
     type: Callable[[str], T],
-) -> T:
-    ...
+) -> T: ...
 
 
 # Same for nargs
@@ -236,13 +224,12 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     default: Sequence[T],
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 @overload
@@ -250,13 +237,12 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     dynamic_default: Optional[Callable[[], Sequence[T]]],
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 @overload
@@ -264,13 +250,12 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     default: Sequence[T],
     type: Callable[[str], T],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 @overload
@@ -278,13 +263,12 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     dynamic_default: Optional[Callable[[], Sequence[T]]],
     type: Callable[[str], T],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 @overload
@@ -292,13 +276,12 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
     type: Callable[[str], T],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 # Overloads for cases with three 'type revealing' field set
@@ -314,8 +297,7 @@ def arg(
     default: T,
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
     type: Callable[[str], T],
-) -> T:
-    ...
+) -> T: ...
 
 
 @overload
@@ -328,8 +310,7 @@ def arg(
     dynamic_default: Optional[Callable[[], T]],
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
     type: Callable[[str], T],
-) -> T:
-    ...
+) -> T: ...
 
 
 # Same for nargs
@@ -340,14 +321,13 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     default: Sequence[T],
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
     type: Callable[[str], T],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 @overload
@@ -355,14 +335,13 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     dynamic_default: Optional[Callable[[], Sequence[T]]],
     dynamic_choices: Optional[Callable[[], Sequence[T]]],
     type: Callable[[str], T],
     nargs: NArgs,
-) -> List[T]:
-    ...
+) -> List[T]: ...
 
 
 # Any fallback
@@ -373,10 +352,9 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
-) -> Any:
-    ...
+) -> Any: ...
 
 
 @overload
@@ -384,11 +362,10 @@ def arg(
     *flags: str,
     positional: bool = ...,
     help: Optional[str] = ...,
-    metavar: Optional[str] = ...,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = ...,
     auto_default_help: bool = ...,
     nargs: NArgs,
-) -> List[Any]:
-    ...
+) -> List[Any]: ...
 
 
 # Impl
@@ -398,7 +375,7 @@ def arg(
     *flags: str,
     positional: bool = False,
     help: Optional[str] = None,
-    metavar: Optional[str] = None,
+    metavar: Optional[Union[str, Tuple[str, ...]]] = None,
     auto_default_help: bool = True,
     nargs: Optional[NArgs] = None,
     default: Optional[object] = None,

--- a/typed_argparse/parser.py
+++ b/typed_argparse/parser.py
@@ -24,6 +24,7 @@ from ._argparse_abstractions import (
     FormatterClass,
     create_argparse_parser,
 )
+from .actions import NamedTupleAction
 from .arg import Arg
 from .arg import arg as make_arg
 from .choices import Choices
@@ -533,7 +534,25 @@ def _build_add_argument_args(
 
         if arg.metavar is not None:
             raise RuntimeError("Cannot set metavar for boolean argument")
+    elif annotation.is_namedtuple:
+        kwargs["action"] = NamedTupleAction
 
+        if arg.type is not None:
+            kwargs["type"] = arg.type
+        else:
+            type_converter = annotation.get_underlying_type_converter()
+            if type_converter is not None:
+                kwargs["type"] = type_converter
+
+        if arg.has_default():
+            default_value = arg.resolve_default()
+            kwargs["default"] = default_value
+
+        if arg.positional:
+            raise RuntimeError("Positional nameduple argument not supported")
+
+        if arg.metavar is not None:
+            raise RuntimeError("Cannot set metavar for namedtuple argument")
     else:
         # We must not declare 'type' for boolean switches, which have an action instead.
         if arg.type is not None:

--- a/typed_argparse/type_utils.py
+++ b/typed_argparse/type_utils.py
@@ -1,7 +1,7 @@
 import sys
 import types
 from enum import Enum
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, NamedTuple
 from typing import Literal as LiteralFromTyping
 from typing import Optional, Tuple, Type, TypeVar, Union, cast, get_type_hints
 
@@ -82,6 +82,14 @@ class TypeAnnotation:
     @property
     def is_bool(self) -> bool:
         return self.raw_type is bool
+
+    @property
+    def is_namedtuple(self) -> bool:
+        orig_bases = getattr(self.raw_type, '__orig_bases__', None)
+        if orig_bases:
+            return NamedTuple in orig_bases
+        else:
+            return False
 
     def get_underlying_type_converter(self) -> Optional[Union[type, Callable[[str], object]]]:
         if isinstance(self.raw_type, type) and not issubclass(self.raw_type, Enum):


### PR DESCRIPTION
Fixes #71

Automatically detects [NamedTuples](https://docs.python.org/3/library/typing.html#typing.NamedTuple) and uses a custom [action](https://docs.python.org/3/library/argparse.html#argparse.Action) to parse the values. Works with `nargs` by modifying the actions `nargs` to be `nargs * len(type._fields)` (if `nargs` is an `int) or requiring the number of values to be a multiple of `len(type._fields)`. `metavar` is automatically set based on the `namedtuples` field names.

[Action](https://docs.python.org/3/library/argparse.html#argparse.Action) requires python 3.9+ which is why i've bumped the version.

