### PR TITLE
support python 3.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,9 @@ jobs:
         # https://github.com/codecov/codecov-action
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          # TODO: configure codecov appropriately or provide token here, then set
+          #fail_ci_if_error: true
+          fail_ci_if_error: false
 
 
   deploy-pypi:

--- a/docs/high_level_api.md
+++ b/docs/high_level_api.md
@@ -175,6 +175,9 @@ If the default `__str__` method of the enum is used, the help output will not di
 A simple solution is hence to overwrite `__str__` so that the value is printed.
 (Note: From Python 3.11 onwards, the `StrEnum` class does that automatically.)
 
+For Python versions *prior to 3.12* it also makes sense to overwrite `__repr__` to
+print the value, as `repr` is used to generate the error output.
+
 
 ```python title="enum_arguments.py"
 --8<-- "examples/high_level_api/enum_arguments.py"

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 project_urls =
     Source = https://github.com/typed-argparse/typed-argparse
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -347,7 +347,9 @@ def test_dynamic_defaults__mutual_exclusiveness_check() -> None:
 
     with pytest.raises(AssertionError) as e:
         parse(Args, [])
-    assert str(e.value) == "default and dynamic_default are mutually exclusive. Please specify either."
+    assert (
+        str(e.value) == "default and dynamic_default are mutually exclusive. Please specify either."
+    )
 
 
 # Dynamic choices

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -429,11 +429,17 @@ def test_enum__basics(use_literal_enum: bool) -> None:
             def __repr__(self) -> str:
                 return self.name
 
+            def __str__(self) -> str:
+                return self.name
+
         class IntEnum(Enum):  # pyright: ignore
             a = 1
             b = 2
 
             def __repr__(self) -> str:
+                return self.name
+
+            def __str__(self) -> str:
                 return self.name
 
     else:
@@ -445,11 +451,17 @@ def test_enum__basics(use_literal_enum: bool) -> None:
             def __repr__(self) -> str:
                 return self.name
 
+            def __str__(self) -> str:
+                return self.name
+
         class IntEnum(int, Enum):  # type: ignore
             a = 1
             b = 2
 
             def __repr__(self) -> str:
+                return self.name
+
+            def __str__(self) -> str:
                 return self.name
 
     class Args(TypedArgs):

--- a/tests/test_parser__subparsers.py
+++ b/tests/test_parser__subparsers.py
@@ -39,13 +39,17 @@ def test_traverse_get_type_mapping__basic() -> None:
 
 
 def test_traverse_get_type_mapping__nested() -> None:
-    class FooXA(TypedArgs): ...
+    class FooXA(TypedArgs):
+        ...
 
-    class FooXB(TypedArgs): ...
+    class FooXB(TypedArgs):
+        ...
 
-    class FooY(TypedArgs): ...
+    class FooY(TypedArgs):
+        ...
 
-    class Bar(TypedArgs): ...
+    class Bar(TypedArgs):
+        ...
 
     group = SubParserGroup(
         SubParser(
@@ -121,13 +125,17 @@ def test_subparser__basic() -> None:
 
 
 def test_subparser__nested() -> None:
-    class FooXA(TypedArgs): ...
+    class FooXA(TypedArgs):
+        ...
 
-    class FooXB(TypedArgs): ...
+    class FooXB(TypedArgs):
+        ...
 
-    class FooY(TypedArgs): ...
+    class FooY(TypedArgs):
+        ...
 
-    class Bar(TypedArgs): ...
+    class Bar(TypedArgs):
+        ...
 
     parser = Parser(
         SubParserGroup(
@@ -391,9 +399,11 @@ def test_subparsers_common_args__subparser_after_positional() -> None:
     class CommonArgs(TypedArgs):
         service: Literal["foo", "bar"] = arg(positional=True)
 
-    class StartArgs(CommonArgs): ...
+    class StartArgs(CommonArgs):
+        ...
 
-    class StopArgs(CommonArgs): ...
+    class StopArgs(CommonArgs):
+        ...
 
     parser = Parser(
         SubParserGroup(
@@ -425,16 +435,22 @@ def test_subparsers_common_args__subparser_after_positional() -> None:
         # python 3.12 onwards changed the formatting output, see https://github.com/python/cpython/issues/86357
         expected_error_start = "argument service: invalid choice: 'start' (choose from foo, bar)"
     else:
-        expected_error_start = "argument service: invalid choice: 'start' (choose from 'foo', 'bar')"
+        expected_error_start = (
+            "argument service: invalid choice: 'start' (choose from 'foo', 'bar')"
+        )
     assert expected_error_start in str(e.error)
 
     with argparse_error() as e:
         parser.parse_args(["invalid", "start"])
 
     if sys.version_info >= (3, 12):
-        expected_error_invalid = "argument service: invalid choice: 'invalid' (choose from foo, bar)"
+        expected_error_invalid = (
+            "argument service: invalid choice: 'invalid' (choose from foo, bar)"
+        )
     else:
-        expected_error_invalid = "argument service: invalid choice: 'invalid' (choose from 'foo', 'bar')"
+        expected_error_invalid = (
+            "argument service: invalid choice: 'invalid' (choose from 'foo', 'bar')"
+        )
     assert expected_error_invalid in str(e.error)
 
 
@@ -442,11 +458,14 @@ def test_subparsers_common_args__subparser_after_positional() -> None:
 
 
 def test_subparsers_executable_mapping_behavior() -> None:
-    class CommonArgs(TypedArgs): ...
+    class CommonArgs(TypedArgs):
+        ...
 
-    class FooArgs(CommonArgs): ...
+    class FooArgs(CommonArgs):
+        ...
 
-    class BarArgs(CommonArgs): ...
+    class BarArgs(CommonArgs):
+        ...
 
     num_run_common = 0
     num_run_foo = 0
@@ -529,9 +548,11 @@ def test_bindings_check() -> None:
         )
     )
 
-    def foo(foo_args: FooArgs) -> None: ...
+    def foo(foo_args: FooArgs) -> None:
+        ...
 
-    def bar(bar_args: BarArgs) -> None: ...
+    def bar(bar_args: BarArgs) -> None:
+        ...
 
     parser.bind(Binding(FooArgs, foo), Binding(BarArgs, bar))
     parser.bind(foo, bar)
@@ -574,7 +595,8 @@ def test_bindings_check() -> None:
     with pytest.raises(ValueError) as e:
         parser.bind(func_with_wrong_first_arg_2)
     assert (
-        "Expected first argument of func_with_wrong_first_arg_2 to be of type 'type' " "but got typing.Union[str, int]."
+        "Expected first argument of func_with_wrong_first_arg_2 to be of type 'type' "
+        "but got typing.Union[str, int]."
     ) == str(e.value)
 
 

--- a/tests/test_parser__subparsers.py
+++ b/tests/test_parser__subparsers.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Union
 
 import pytest
@@ -38,17 +39,13 @@ def test_traverse_get_type_mapping__basic() -> None:
 
 
 def test_traverse_get_type_mapping__nested() -> None:
-    class FooXA(TypedArgs):
-        ...
+    class FooXA(TypedArgs): ...
 
-    class FooXB(TypedArgs):
-        ...
+    class FooXB(TypedArgs): ...
 
-    class FooY(TypedArgs):
-        ...
+    class FooY(TypedArgs): ...
 
-    class Bar(TypedArgs):
-        ...
+    class Bar(TypedArgs): ...
 
     group = SubParserGroup(
         SubParser(
@@ -124,17 +121,13 @@ def test_subparser__basic() -> None:
 
 
 def test_subparser__nested() -> None:
-    class FooXA(TypedArgs):
-        ...
+    class FooXA(TypedArgs): ...
 
-    class FooXB(TypedArgs):
-        ...
+    class FooXB(TypedArgs): ...
 
-    class FooY(TypedArgs):
-        ...
+    class FooY(TypedArgs): ...
 
-    class Bar(TypedArgs):
-        ...
+    class Bar(TypedArgs): ...
 
     parser = Parser(
         SubParserGroup(
@@ -398,11 +391,9 @@ def test_subparsers_common_args__subparser_after_positional() -> None:
     class CommonArgs(TypedArgs):
         service: Literal["foo", "bar"] = arg(positional=True)
 
-    class StartArgs(CommonArgs):
-        ...
+    class StartArgs(CommonArgs): ...
 
-    class StopArgs(CommonArgs):
-        ...
+    class StopArgs(CommonArgs): ...
 
     parser = Parser(
         SubParserGroup(
@@ -430,25 +421,32 @@ def test_subparsers_common_args__subparser_after_positional() -> None:
 
     with argparse_error() as e:
         parser.parse_args(["start"])
-    assert "argument service: invalid choice: 'start' (choose from 'foo', 'bar')" in str(e.error)
+    if sys.version_info >= (3, 12):
+        # python 3.12 onwards changed the formatting output, see https://github.com/python/cpython/issues/86357
+        expected_error_start = "argument service: invalid choice: 'start' (choose from foo, bar)"
+    else:
+        expected_error_start = "argument service: invalid choice: 'start' (choose from 'foo', 'bar')"
+    assert expected_error_start in str(e.error)
 
     with argparse_error() as e:
         parser.parse_args(["invalid", "start"])
-    assert "argument service: invalid choice: 'invalid' (choose from 'foo', 'bar')" in str(e.error)
+
+    if sys.version_info >= (3, 12):
+        expected_error_invalid = "argument service: invalid choice: 'invalid' (choose from foo, bar)"
+    else:
+        expected_error_invalid = "argument service: invalid choice: 'invalid' (choose from 'foo', 'bar')"
+    assert expected_error_invalid in str(e.error)
 
 
 # Subparsers executable mapping behavior
 
 
 def test_subparsers_executable_mapping_behavior() -> None:
-    class CommonArgs(TypedArgs):
-        ...
+    class CommonArgs(TypedArgs): ...
 
-    class FooArgs(CommonArgs):
-        ...
+    class FooArgs(CommonArgs): ...
 
-    class BarArgs(CommonArgs):
-        ...
+    class BarArgs(CommonArgs): ...
 
     num_run_common = 0
     num_run_foo = 0
@@ -531,11 +529,9 @@ def test_bindings_check() -> None:
         )
     )
 
-    def foo(foo_args: FooArgs) -> None:
-        ...
+    def foo(foo_args: FooArgs) -> None: ...
 
-    def bar(bar_args: BarArgs) -> None:
-        ...
+    def bar(bar_args: BarArgs) -> None: ...
 
     parser.bind(Binding(FooArgs, foo), Binding(BarArgs, bar))
     parser.bind(foo, bar)
@@ -578,8 +574,7 @@ def test_bindings_check() -> None:
     with pytest.raises(ValueError) as e:
         parser.bind(func_with_wrong_first_arg_2)
     assert (
-        "Expected first argument of func_with_wrong_first_arg_2 to be of type 'type' "
-        "but got typing.Union[str, int]."
+        "Expected first argument of func_with_wrong_first_arg_2 to be of type 'type' " "but got typing.Union[str, int]."
     ) == str(e.value)
 
 

--- a/tests/test_typed_args.py
+++ b/tests/test_typed_args.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 from typing import List, Optional, Type, TypeVar, overload
 
 import typed_argparse as tap
@@ -332,6 +333,16 @@ def test_eq__well_behaved() -> None:
 
 def test_check_reserved_names() -> None:
     fields_class = set(TypedArgs.__dict__)
+    assert sys.version_info.major == 3
+    version_dependent_data_model_fields = []
+    if sys.version_info.minor >= 13:
+        version_dependent_data_model_fields.extend(
+            [
+                "__static_attributes__",
+                "__firstlineno__",
+            ]
+        )
+
     assert fields_class == {
         "__dataclass_transform__",
         "__dict__",
@@ -346,4 +357,5 @@ def test_check_reserved_names() -> None:
         "__weakref__",
         "from_argparse",
         "get_choices_from",
+        *version_dependent_data_model_fields,
     }


### PR DESCRIPTION
Make the CI pass for python 3.12 and 3.13.

As for support for python 3.12 and 3.13 it seems like the argparse.py in the standard library changed from

3.8:

```python
 def _check_value(self, action, value):
        # converted value must be one of the choices (if specified)
        if action.choices is not None and value not in action.choices:
            args = {'value': value,
                    'choices': ', '.join(map(repr, action.choices))}
            msg = _('invalid choice: %(value)r (choose from %(choices)s)')
            raise ArgumentError(action, msg % args)

```

to 3.12/13 (see  https://github.com/python/cpython/commit/d3d306a9d63e879d4eac42694b94ed4a7f440332 )

```python
def _check_value(self, action, value):
        # converted value must be one of the choices (if specified)
        choices = action.choices
        if choices is not None:
            if isinstance(choices, str):
                choices = iter(choices)
            if value not in choices:
                args = {'value': str(value),
                        'choices': ', '.join(map(str, action.choices))}
                msg = _('invalid choice: %(value)r (choose from %(choices)s)')
                raise ArgumentError(action, msg % args)
```

so in particular now `str` is used rather than `repr` to format the output if an invalid choice is used.
Since both `__str__` and `__repr__` are defined by default for enums and we only overwrite `__repr__` in the tests, the new argparse will use the non-overwritten `__str__` rather than the overwritten `__repr__`.

This PR hence contains a) adaptions to overwrite `__str__` for python 3.12 onwards and b) fixes to the expected output (no quotes any more). The latter changes are similar to the changes in the tests for argparse.

Another point is, that the python data model changed and now includes [two more dunder-fields](https://docs.python.org/3/whatsnew/3.13.html), which are added to the tests for python >= 3.13.