### PR TITLE
allow the `runner` function to return somethething

### DIFF
--- a/typed_argparse/parser.py
+++ b/typed_argparse/parser.py
@@ -40,12 +40,12 @@ T = TypeVar("T", bound=TypedArgs)
 # mismatch. Also, annotating the generics below in the usages felt awkward. This is probably a
 # case where we want type erasure.
 class Binding:
-    def __init__(self, arg_type: Type[T], func: Callable[[T], None]):
+    def __init__(self, arg_type: Type[T], func: Callable[[T], Any]):
         self.arg_type: Type[TypedArgs] = arg_type
-        self.func: Callable[[Any], None] = func
+        self.func: Callable[[Any], Any] = func
 
     @staticmethod
-    def from_func(func: Callable[[Any], None]) -> Binding:
+    def from_func(func: Callable[[Any], Any]) -> Binding:
         if not hasattr(func, "__annotations__"):
             raise ValueError(f"Function {func.__name__} misses type annotations.")
 
@@ -278,7 +278,7 @@ class App:
 
 ArgsOrGroup = Union[Type[TypedArgs], SubParserGroup]
 
-AnyBinding = Union[Binding, Callable[[Any], None]]
+AnyBinding = Union[Binding, Callable[[Any], Any]]
 Bindings = List[AnyBinding]
 LazyBindings = Callable[[], Bindings]
 EagerOrLazyBindings = Union[Bindings, LazyBindings]


### PR DESCRIPTION
allow the function bound to the parser to return something

Does it hurt to allow the `runner` function to return something?
If not, how about we allow it?

Then we could re-use the code that we call via `typed-argparse` also as a library.

For example when we generate an output file from some data, the runner could generate the output file and then return the data or some intermediate representations of it.
If you later need to further drill into this output, you can easily call the runner in ipython/jupyter/..., get the output as you did before, but also get intermediate data.