### PR TITLE
support python 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
 
@@ -59,12 +59,12 @@ jobs:
           ./scripts/test
 
       - name: Check example outputs
-        if: matrix.python-version == '3.8'
+        if: matrix.python-version == '3.10'
         run: |
           ./scripts/generate_console_outputs
 
       - name: Upload to codecov.io
-        if: matrix.python-version == '3.8'
+        if: matrix.python-version == '3.10'
         # https://github.com/codecov/codecov-action
         uses: codecov/codecov-action@v3
         with:
@@ -87,7 +87,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Install wheel
         run: pip install wheel
@@ -130,7 +130,7 @@ jobs:
       - name: Set up python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Install mkdocs-material
         run: pip install mkdocs-material

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 $ pip install typed-argparse
 ```
 
-The only requirement is a modern Python (3.8+).
+The only requirement is a modern Python (3.10+).
 
 
 ## Basic Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@
 $ pip install typed-argparse
 ```
 
-The only requirement is a modern Python (3.8+).
+The only requirement is a modern Python (3.10+).
 
 
 ## Next step

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 project_urls =
     Source = https://github.com/typed-argparse/typed-argparse
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
@@ -30,7 +28,7 @@ include_package_data = true
 install_requires =
     setuptools
     importlib_resources
-python_requires = >=3.8
+python_requires = >=3.10
 
 [tool:pytest]
 addopts = --cov=typed_argparse --cov-report term-missing --cov-report html:.cov_html --cov-report=xml

--- a/tests/_testing_utils.py
+++ b/tests/_testing_utils.py
@@ -1,7 +1,7 @@
 import argparse
 import re
 import sys
-from contextlib import contextmanager
+from contextlib import contextmanager, AbstractContextManager
 from typing import Generator, Optional
 
 import pytest
@@ -50,6 +50,18 @@ def argparse_error() -> Generator[ArgparseErrorWrapper, None, None]:
 
     assert isinstance(e.value.__context__, argparse.ArgumentError)
     wrapper.error = e.value.__context__
+
+
+def argparse_illegal_default() -> AbstractContextManager[object]:
+    # argparse >= python3.14 no longer checks `default` against `choices`
+    # see https://github.com/python/cpython/commit/dac4ec52866e4068f3ac33b4da1e1a1fe6fc2cba
+    err_kind: type[BaseException]
+    if sys.version_info.minor >= 14:
+        err_kind = TypeError
+    else:
+        err_kind = SystemExit
+
+    return pytest.raises(err_kind)
 
 
 def remove_ansii_escape_sequences(s: str) -> str:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,6 +13,7 @@ from typed_argparse.parser import Bindings
 
 from ._testing_utils import (
     argparse_error,
+    argparse_illegal_default,
     compare_verbose,
     pre_python_3_10,
     remove_ansii_escape_sequences,
@@ -775,7 +776,7 @@ def test_nargs_with_choices__literal_illegal_default() -> None:
     class Args(TypedArgs):
         actions: List[Actions] = arg(positional=True, default=["a", "b", "c"])  # type: ignore
 
-    with argparse_error():
+    with argparse_illegal_default():
         parse(Args, [])
 
 
@@ -808,7 +809,7 @@ def test_nargs_with_choices__enum_illegal_default() -> None:
             default=[Actions.a, Actions.b, "c"],  # type: ignore
         )
 
-    with argparse_error():
+    with argparse_illegal_default():
         parse(Args, [])
 
 

--- a/tests/test_parser__subparsers.py
+++ b/tests/test_parser__subparsers.py
@@ -596,7 +596,7 @@ def test_bindings_check() -> None:
         parser.bind(func_with_wrong_first_arg_2)
     assert (
         "Expected first argument of func_with_wrong_first_arg_2 to be of type 'type' "
-        "but got typing.Union[str, int]."
+        f"but got {Union[str, int]}."
     ) == str(e.value)
 
 

--- a/tests/test_typed_args.py
+++ b/tests/test_typed_args.py
@@ -342,6 +342,13 @@ def test_check_reserved_names() -> None:
                 "__firstlineno__",
             ]
         )
+    if sys.version_info.minor >= 14:
+        version_dependent_data_model_fields.extend(
+            [
+                "__annotate_func__",
+                "__annotations_cache__",
+            ]
+        )
 
     assert fields_class == {
         "__dataclass_transform__",

--- a/typed_argparse/type_utils.py
+++ b/typed_argparse/type_utils.py
@@ -3,7 +3,7 @@ import types
 from enum import Enum
 from typing import Callable, Dict, List
 from typing import Literal as LiteralFromTyping
-from typing import Optional, Tuple, Type, TypeVar, Union, cast, get_type_hints
+from typing import Optional, Tuple, TypeVar, Union, cast, get_type_hints
 
 from typing_extensions import Literal
 
@@ -97,7 +97,7 @@ class TypeAnnotation:
             allowed_values_if_literal = self.get_allowed_values_if_literal()
             if allowed_values_if_literal is not None:
                 allowed_values = allowed_values_if_literal
-                return _create_literal_type_converter(allowed_values)
+                return _create_choices_type_converter(allowed_values)
 
             allowed_values_if_enum = self.get_allowed_values_if_enum()
             if (
@@ -106,8 +106,7 @@ class TypeAnnotation:
                 and issubclass(self.raw_type, Enum)
             ):
                 allowed_values = allowed_values_if_enum
-                enum_type: Type[Enum] = self.raw_type
-                return _create_enum_type_converter(allowed_values, enum_type)
+                return _create_choices_type_converter(allowed_values)
 
             return None
 
@@ -261,7 +260,7 @@ def assert_not_none(x: Optional[T]) -> T:
     return x
 
 
-def _create_literal_type_converter(allowed_values: Tuple[object, ...]) -> Callable[[str], object]:
+def _create_choices_type_converter(allowed_values: Tuple[object, ...]) -> Callable[[str], object]:
     def converter(x: str) -> object:
 
         for allowed_value in allowed_values:
@@ -277,40 +276,24 @@ def _create_literal_type_converter(allowed_values: Tuple[object, ...]) -> Callab
 
         # Here we could raise a TypeError or ValueError, but it looks like relying
         # on `choices` instead actually produces a better error message.
-        return x
-
-    return converter
-
-
-def _create_enum_type_converter(
-    allowed_values: Tuple[Enum, ...], enum_type: Type[Enum]
-) -> Callable[[str], object]:
-    def converter(x: str) -> object:
-
-        for allowed_value in allowed_values:
-            assert isinstance(allowed_value, Enum)
-            if _fuzzy_compare(x, allowed_value.name):
-                return allowed_value
-            else:
-                if _fuzzy_compare(x, allowed_value.value):
-                    return allowed_value
-                else:
-                    try:
-                        x_converted = type(allowed_value.value)(x)
-                        if _fuzzy_compare(x_converted, allowed_value.value):
-                            return allowed_value
-                    except (ValueError, TypeError):
-                        pass
-
-        # Here we could raise a TypeError or ValueError, but it looks like relying
-        # on `choices` instead actually produces a better error message.
+        #
+        # XXX: no longer true for default values since 3.14
+        # see https://github.com/python/cpython/commit/dac4ec52866e4068f3ac33b4da1e1a1fe6fc2cba
         return x
 
     return converter
 
 
 def _fuzzy_compare(a: object, b: object) -> bool:
+    if isinstance(b, Enum):
+        return a == b or _fuzzy_compare(a, b.name) or _fuzzy_compare(a, b.value)
+
+    if isinstance(a, int):
+        a = str(a)
+    if isinstance(b, int):
+        b = str(b)
+
     if isinstance(a, str) and isinstance(b, str):
         return a.lower().replace("-", "_") == b.lower().replace("-", "_")
-    else:
-        return a == b
+
+    return a == b


### PR DESCRIPTION
* argparse no longer checks `default` values against `choices`, which means a different error is raised https://github.com/python/cpython/commit/dac4ec52866e4068f3ac33b4da1e1a1fe6fc2cba
* error message shows union as `a | b` rather than `typing.Union[a, b]`
* new (python-internal) fields `__annotate_func__` and `__annotations_cache__` https://github.com/python/cpython/commit/07b8d3117fdbc4e5be55aab0be428c278ec84e12